### PR TITLE
[ES-393] language render issue in mock-relying-party-ui

### DIFF
--- a/helm/mock-relying-party-ui/templates/deployment.yaml
+++ b/helm/mock-relying-party-ui/templates/deployment.yaml
@@ -124,6 +124,8 @@ spec:
               value: {{ .Values.mock_relying_party_ui.CLAIMS_REGISTRATION | quote }}
             - name: DEFAULT_LANG
               value: {{ .Values.mock_relying_party_ui.DEFAULT_LANG }}
+            - name: FALLBACK_LANG
+              value: {{ .Values.mock_relying_party_ui.FALLBACK_LANG | quote }}
 
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}

--- a/helm/mock-relying-party-ui/templates/deployment.yaml
+++ b/helm/mock-relying-party-ui/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
               value: {{ .Values.mock_relying_party_ui.CLAIMS_USER_PROFILE | quote }}
             - name: CLAIMS_REGISTRATION
               value: {{ .Values.mock_relying_party_ui.CLAIMS_REGISTRATION | quote }}
+            - name: DEFAULT_LANG
+              value: {{ .Values.mock_relying_party_ui.DEFAULT_LANG }}
 
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}

--- a/helm/mock-relying-party-ui/values.yaml
+++ b/helm/mock-relying-party-ui/values.yaml
@@ -434,6 +434,7 @@ mock_relying_party_ui:
   CLAIMS_USER_PROFILE: '%7B%22userinfo%22:%7B%22given_name%22:%7B%22essential%22:true%7D,%22phone_number%22:%7B%22essential%22:false%7D,%22email%22:%7B%22essential%22:true%7D,%22picture%22:%7B%22essential%22:false%7D,%22gender%22:%7B%22essential%22:false%7D,%22birthdate%22:%7B%22essential%22:false%7D,%22address%22:%7B%22essential%22:false%7D%7D,%22id_token%22:%7B%7D%7D'
   CLAIMS_REGISTRATION: '%7B%22userinfo%22:%7B%22given_name%22:%7B%22essential%22:true%7D,%22phone_number%22:%7B%22essential%22:false%7D,%22email%22:%7B%22essential%22:true%7D,%22picture%22:%7B%22essential%22:false%7D,%22gender%22:%7B%22essential%22:false%7D,%22birthdate%22:%7B%22essential%22:false%7D,%22address%22:%7B%22essential%22:false%7D%7D,%22id_token%22:%7B%7D%7D'
   DEFAULT_LANG: en
+  FALLBACK_LANG: '%7B%22label%22%3A%22English%22%2C%22value%22%3A%22en%22%7D'
 ## oidc UI swagger should have only internal access. Hence linked to internal gateway
 ## We create a gateway for oidc specific URL(s) listed under `hosts`
 istio:

--- a/helm/mock-relying-party-ui/values.yaml
+++ b/helm/mock-relying-party-ui/values.yaml
@@ -433,6 +433,7 @@ mock_relying_party_ui:
   SCOPE_USER_PROFILE: openid profile
   CLAIMS_USER_PROFILE: '%7B%22userinfo%22:%7B%22given_name%22:%7B%22essential%22:true%7D,%22phone_number%22:%7B%22essential%22:false%7D,%22email%22:%7B%22essential%22:true%7D,%22picture%22:%7B%22essential%22:false%7D,%22gender%22:%7B%22essential%22:false%7D,%22birthdate%22:%7B%22essential%22:false%7D,%22address%22:%7B%22essential%22:false%7D%7D,%22id_token%22:%7B%7D%7D'
   CLAIMS_REGISTRATION: '%7B%22userinfo%22:%7B%22given_name%22:%7B%22essential%22:true%7D,%22phone_number%22:%7B%22essential%22:false%7D,%22email%22:%7B%22essential%22:true%7D,%22picture%22:%7B%22essential%22:false%7D,%22gender%22:%7B%22essential%22:false%7D,%22birthdate%22:%7B%22essential%22:false%7D,%22address%22:%7B%22essential%22:false%7D%7D,%22id_token%22:%7B%7D%7D'
+  DEFAULT_LANG: en
 ## oidc UI swagger should have only internal access. Hence linked to internal gateway
 ## We create a gateway for oidc specific URL(s) listed under `hosts`
 istio:

--- a/mock-relying-party-ui/public/env-config.js
+++ b/mock-relying-party-ui/public/env-config.js
@@ -15,5 +15,6 @@ window._env_ = {
   PROMPT: "consent",
   GRANT_TYPE: "authorization_code",
   MAX_AGE: 21,
-  CLAIMS_LOCALES: "en"
+  CLAIMS_LOCALES: "en",
+  DEFAULT_LANG: "en"
 };

--- a/mock-relying-party-ui/public/env-config.js
+++ b/mock-relying-party-ui/public/env-config.js
@@ -16,5 +16,6 @@ window._env_ = {
   GRANT_TYPE: "authorization_code",
   MAX_AGE: 21,
   CLAIMS_LOCALES: "en",
-  DEFAULT_LANG: "en"
+  DEFAULT_LANG: "en",
+  FALLBACK_LANG: "%7B%22label%22%3A%22English%22%2C%22value%22%3A%22en%22%7D"
 };

--- a/mock-relying-party-ui/src/components/NavHeader.js
+++ b/mock-relying-party-ui/src/components/NavHeader.js
@@ -7,7 +7,7 @@ export default function NavHeader({ langOptions, i18nKeyPrefix = "background" })
     keyPrefix: i18nKeyPrefix,
   });
   const [selectedLang, setSelectedLang] = useState();
-
+  const fallbackLang = {label: "English", value: "en"};
 
   const changeLanguageHandler = (e) => {
     i18n.changeLanguage(e.value);
@@ -21,21 +21,22 @@ export default function NavHeader({ langOptions, i18nKeyPrefix = "background" })
     }),
   };
 
+  const setLanguage = (lng) => {
+    let lang = langOptions.find((op)=> op.value === lng);
+    console.log({lang});
+    console.log({langOptions});
+    setSelectedLang(lang ?? fallbackLang);
+  }
+
   useEffect(() => {
     if (!langOptions || langOptions.length === 0) {
       return;
     }
 
-    let lang = langOptions.find((option) => {
-      return option.value === i18n.language;
-    });
-    setSelectedLang(lang);
+    setLanguage(i18n.language);
     //Gets fired when changeLanguage got called.
     i18n.on("languageChanged", function (lng) {
-      let lang = langOptions.find((option) => {
-        return option.value === lng;
-      });
-      setSelectedLang(lang);
+      setLanguage(lng);
     });
   }, [langOptions]);
 

--- a/mock-relying-party-ui/src/components/NavHeader.js
+++ b/mock-relying-party-ui/src/components/NavHeader.js
@@ -23,8 +23,6 @@ export default function NavHeader({ langOptions, i18nKeyPrefix = "background" })
 
   const setLanguage = (lng) => {
     let lang = langOptions.find((op)=> op.value === lng);
-    console.log({lang});
-    console.log({langOptions});
     setSelectedLang(lang ?? fallbackLang);
   }
 

--- a/mock-relying-party-ui/src/components/NavHeader.js
+++ b/mock-relying-party-ui/src/components/NavHeader.js
@@ -7,7 +7,14 @@ export default function NavHeader({ langOptions, i18nKeyPrefix = "background" })
     keyPrefix: i18nKeyPrefix,
   });
   const [selectedLang, setSelectedLang] = useState();
-  const fallbackLang = {label: "English", value: "en"};
+  // fallback language from the environment configuration
+  const fallbackLangObj = decodeURIComponent(window._env_.FALLBACK_LANG);
+  // converting it to JSON, and if the fallback language
+  // is also not present, taking english as default
+  const fallbackLang =
+    fallbackLangObj !== ""
+      ? JSON.parse(fallbackLangObj)
+      : { label: "English", value: "en" };
 
   const changeLanguageHandler = (e) => {
     i18n.changeLanguage(e.value);
@@ -21,10 +28,13 @@ export default function NavHeader({ langOptions, i18nKeyPrefix = "background" })
     }),
   };
 
+  // check language in the langOptions,
+  // which came through langCnfigService
+  // then setting that language as selected one
   const setLanguage = (lng) => {
-    let lang = langOptions.find((op)=> op.value === lng);
+    let lang = langOptions.find((op) => op.value === lng);
     setSelectedLang(lang ?? fallbackLang);
-  }
+  };
 
   useEffect(() => {
     if (!langOptions || langOptions.length === 0) {

--- a/mock-relying-party-ui/src/constants/clientDetails.js
+++ b/mock-relying-party-ui/src/constants/clientDetails.js
@@ -1,26 +1,47 @@
+// method to check non-empty and non-null
+// values, if present then give default value
+const checkEmptyNullValue = (initialValue, defaultValue) =>
+  initialValue && initialValue !== "" ? initialValue : defaultValue;
+
 const state = "eree2311";
 const nonce = "ere973eieljznge2311";
 const responseType = "code";
-const scopeUserProfile = window._env_.SCOPE_USER_PROFILE ?? "openid profile";
-const scopeRegistration = window._env_.SCOPE_REGISTRATION ?? "openid profile";
-const display = window._env_.DISPLAY ?? "page";
-const prompt = window._env_.PROMPT ?? "consent";
-const grantType = window._env_.GRANT_TYPE ?? "authorization_code";
+const scopeUserProfile = checkEmptyNullValue(
+  window._env_.SCOPE_USER_PROFILE,
+  "openid profile"
+);
+const scopeRegistration = checkEmptyNullValue(
+  window._env_.SCOPE_REGISTRATION,
+  "openid profile"
+);
+const display = checkEmptyNullValue(window._env_.DISPLAY, "page");
+const prompt = checkEmptyNullValue(window._env_.PROMPT, "consent");
+const grantType = checkEmptyNullValue(
+  window._env_.GRANT_TYPE,
+  "authorization_code"
+);
 const maxAge = window._env_.MAX_AGE;
-const claimsLocales = window._env_.CLAIMS_LOCALES ?? "en";
+const claimsLocales = checkEmptyNullValue(window._env_.CLAIMS_LOCALES, "en");
 const authorizeEndpoint = "/authorize";
 const clientId = window._env_.CLIENT_ID;
 const uibaseUrl = window._env_.ESIGNET_UI_BASE_URL;
-const redirect_uri_userprofile =
-  window._env_.REDIRECT_URI_USER_PROFILE ?? window._env_.REDIRECT_URI;
-const redirect_uri_registration =
-  window._env_.REDIRECT_URI_REGISTRATION ?? window._env_.REDIRECT_URI;
+const redirect_uri_userprofile = checkEmptyNullValue(
+  window._env_.REDIRECT_URI_USER_PROFILE,
+  window._env_.REDIRECT_URI
+);
+const redirect_uri_registration = checkEmptyNullValue(
+  window._env_.REDIRECT_URI_REGISTRATION,
+  window._env_.REDIRECT_URI
+);
 const acr_values = window._env_.ACRS;
-const userProfileClaims =
-  window._env_.CLAIMS_USER_PROFILE;
-const registrationClaims =
-  window._env_.CLAIMS_REGISTRATION;
-
+const userProfileClaims = checkEmptyNullValue(
+  window._env_.CLAIMS_USER_PROFILE,
+  "{}"
+);
+const registrationClaims = checkEmptyNullValue(
+  window._env_.CLAIMS_REGISTRATION,
+  "{}"
+);
 
 const claims = {
   userinfo: {
@@ -47,7 +68,7 @@ const claims = {
     },
   },
   id_token: {},
-}
+};
 
 const clientDetails = {
   nonce: nonce,
@@ -67,7 +88,7 @@ const clientDetails = {
   uibaseUrl: uibaseUrl,
   authorizeEndpoint: authorizeEndpoint,
   userProfileClaims: userProfileClaims ?? encodeURI(JSON.stringify(claims)),
-  registrationClaims: registrationClaims ?? encodeURI(JSON.stringify(claims))
+  registrationClaims: registrationClaims ?? encodeURI(JSON.stringify(claims)),
 };
 
 export default clientDetails;

--- a/mock-relying-party-ui/src/i18n.js
+++ b/mock-relying-party-ui/src/i18n.js
@@ -12,6 +12,7 @@ i18n
   .use(initReactI18next)
   // init i18next
   .init({
+    lng: window._env_.DEFAULT_LANG,
     debug: false,
     fallbackLng: "en", //window["envConfigs"].defaultLang, //default language
     interpolation: {

--- a/mock-relying-party-ui/src/i18n.js
+++ b/mock-relying-party-ui/src/i18n.js
@@ -3,6 +3,17 @@ import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 
+
+// Function to extract query parameters from the URL
+const getQueryParam = (param) => {
+    // getting all query params
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    return urlSearchParams.get(param);
+}
+
+// Extract ui_locales and its value, from the current url
+const uiLocales = getQueryParam('ui_locales');
+
 i18n
   // detect available locale files
   .use(Backend)
@@ -12,7 +23,7 @@ i18n
   .use(initReactI18next)
   // init i18next
   .init({
-    lng: window._env_.DEFAULT_LANG,
+    lng: uiLocales ?? window._env_.DEFAULT_LANG,
     debug: false,
     fallbackLng: "en", //window["envConfigs"].defaultLang, //default language
     interpolation: {


### PR DESCRIPTION
By default it is taking `en-US` for language, make changes in `deployment.yaml` & `values.yaml` of mock-relying-party-ui helm's chart to accommodate `DEFAULT_LANG` in environment config.

Also added fallback `english` language, if the given language is not present.