### PR TITLE
[ES-1426] json ignore unknown for identityData

### DIFF
--- a/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/dto/IdentityData.java
+++ b/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/dto/IdentityData.java
@@ -12,12 +12,14 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.mosip.esignet.mock.identitysystem.util.ErrorConstants;
 import io.mosip.esignet.mock.identitysystem.validator.IdData;
 import lombok.Data;
 
 @Data
 @IdData
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IdentityData {
 	
 	@NotBlank(message = ErrorConstants.INVALID_INDIVIDUAL_ID)


### PR DESCRIPTION
Without it we are passing data for oauth/v2/token, it throws error.

So for that, we are using json ignore unknown properties