### PR TITLE
[INJICERT-434] optionally support using arbitrary field as PSUT value

### DIFF
--- a/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/service/impl/AuthenticationServiceImpl.java
+++ b/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/service/impl/AuthenticationServiceImpl.java
@@ -8,7 +8,6 @@ package io.mosip.esignet.mock.identitysystem.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nimbusds.jose.jwk.RSAKey;
 import io.mosip.esignet.mock.identitysystem.dto.*;
@@ -98,8 +97,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     @Value("#{${mosip.mock.ida.identity-openid-claims-mapping}}")
     private Map<String,String> oidcClaimsMapping;
 
-    @Value("${mosip.mock.ida.kyc.expose-individualID:false}")
-    private boolean exposeIndividualID;
+    @Value("${mosip.mock.ida.kyc.psut.field:psut}")
+    private String psutField;
 
     ArrayList<String> trnHash = new ArrayList<>();
 
@@ -124,10 +123,10 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         KycAuthResponseDto kycAuthResponseDto = new KycAuthResponseDto();
         kycAuthResponseDto.setAuthStatus(authStatus);
         kycAuthResponseDto.setKycToken(kycAuth.getKycToken());
-        if (exposeIndividualID) {
-            kycAuthResponseDto.setPartnerSpecificUserToken(kycAuth.getIndividualId());
-        } else {
+        if (psutField.equals("psut")) {
             kycAuthResponseDto.setPartnerSpecificUserToken(kycAuth.getPartnerSpecificUserToken());
+        } else {
+            kycAuthResponseDto.setPartnerSpecificUserToken(HelperUtil.getIdentityDataValue(identityData, psutField, defaultLanguage));
         }
         if(kycAuthDto.isClaimMetadataRequired()) {
             kycAuthResponseDto.setClaimMetadata(getVerifiedClaimMetadata(kycAuthDto.getIndividualId(), identityData));

--- a/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/service/impl/AuthenticationServiceImpl.java
+++ b/mock-identity-system/src/main/java/io/mosip/esignet/mock/identitysystem/service/impl/AuthenticationServiceImpl.java
@@ -98,6 +98,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     @Value("#{${mosip.mock.ida.identity-openid-claims-mapping}}")
     private Map<String,String> oidcClaimsMapping;
 
+    @Value("${mosip.mock.ida.kyc.expose-individualID:false}")
+    private boolean exposeIndividualID;
+
     ArrayList<String> trnHash = new ArrayList<>();
 
     @Override
@@ -121,8 +124,11 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         KycAuthResponseDto kycAuthResponseDto = new KycAuthResponseDto();
         kycAuthResponseDto.setAuthStatus(authStatus);
         kycAuthResponseDto.setKycToken(kycAuth.getKycToken());
-        kycAuthResponseDto.setPartnerSpecificUserToken(kycAuth.getPartnerSpecificUserToken());
-
+        if (exposeIndividualID) {
+            kycAuthResponseDto.setPartnerSpecificUserToken(kycAuth.getIndividualId());
+        } else {
+            kycAuthResponseDto.setPartnerSpecificUserToken(kycAuth.getPartnerSpecificUserToken());
+        }
         if(kycAuthDto.isClaimMetadataRequired()) {
             kycAuthResponseDto.setClaimMetadata(getVerifiedClaimMetadata(kycAuthDto.getIndividualId(), identityData));
         }

--- a/mock-identity-system/src/main/resources/application-default.properties
+++ b/mock-identity-system/src/main/resources/application-default.properties
@@ -121,7 +121,7 @@ mosip.esignet.mock.authenticator.ida.otp-channels=email,phone
 
 mosip.esignet.mock.supported-fields=individualId,pin,givenName,familyName,gender,dateOfBirth,email,phone,streetAddress,locality,region,postalCode,country
 mosip.mock.ida.kba.default.field-language=eng
-
+mosip.mock.ida.kyc.expose-individualID=false
 #Related to health check of hsm
 mosip.kernel.keymgr.hsm.health.check.enabled=false
 mosip.kernel.keymgr.hsm.health.key.app-id=MOCK_AUTHENTICATION_SERVICE

--- a/mock-identity-system/src/main/resources/application-default.properties
+++ b/mock-identity-system/src/main/resources/application-default.properties
@@ -121,7 +121,7 @@ mosip.esignet.mock.authenticator.ida.otp-channels=email,phone
 
 mosip.esignet.mock.supported-fields=individualId,pin,givenName,familyName,gender,dateOfBirth,email,phone,streetAddress,locality,region,postalCode,country
 mosip.mock.ida.kba.default.field-language=eng
-mosip.mock.ida.kyc.expose-individualID=false
+mosip.mock.ida.kyc.psut.field=psut
 #Related to health check of hsm
 mosip.kernel.keymgr.hsm.health.check.enabled=false
 mosip.kernel.keymgr.hsm.health.key.app-id=MOCK_AUTHENTICATION_SERVICE

--- a/mock-identity-system/src/main/resources/application-local.properties
+++ b/mock-identity-system/src/main/resources/application-local.properties
@@ -73,4 +73,4 @@ mosip.mock.ida.identity-openid-claims-mapping={"fullName":"name","name":"name","
 #We can use any field from the IdentityData for KBI
 mosip.esignet.authenticator.auth-factor.kbi.field-details={{"id":"phone", "type":"text", "format":""},{"id":"email", "type":"text", "format":""},{"id":"dateOfBirth", "type":"date", "format":"yyyy-MM-dd"}}
 mosip.mock.ida.kbi.default.field-language=eng
-mosip.mock.ida.kyc.expose-individualID=false
+mosip.mock.ida.kyc.psut.field=psut

--- a/mock-identity-system/src/main/resources/application-local.properties
+++ b/mock-identity-system/src/main/resources/application-local.properties
@@ -73,3 +73,4 @@ mosip.mock.ida.identity-openid-claims-mapping={"fullName":"name","name":"name","
 #We can use any field from the IdentityData for KBI
 mosip.esignet.authenticator.auth-factor.kbi.field-details={{"id":"phone", "type":"text", "format":""},{"id":"email", "type":"text", "format":""},{"id":"dateOfBirth", "type":"date", "format":"yyyy-MM-dd"}}
 mosip.mock.ida.kbi.default.field-language=eng
+mosip.mock.ida.kyc.expose-individualID=false


### PR DESCRIPTION
Purpose: to break Certify <--> Mock DataProviderPlugin dependency wrt
         OIDCTransaction object stored in Redis

**Config changes required**:

* Introduces a config but does not break existing default behaviour, so
  no explicit change required
* Add config to set an arbitrary field in-place of the PSUT in the `KyccAuthResponse`

Signed-off-by: Harsh Vardhan <harsh59v@gmail.com>
