### PR TITLE
Docker container failing to find libpkcs11-proxy.so

### DIFF
--- a/mock-identity-system/Dockerfile
+++ b/mock-identity-system/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get -y update \
 && echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${hsm_local_dir}/install.sh" >> /etc/sudoers \
 && mkdir -p ${loader_path} \
 && chmod +x configure_start.sh \
-&& wget https://raw.githubusercontent.com/mosip/artifactory-ref-impl/master/artifacts/src/hsm/client.zip -O client.zip \
+&& wget https://raw.githubusercontent.com/mosip/artifactory-ref-impl/v1.2.0.3/artifacts/src/hsm/client.zip -O client.zip \
 && chown -R ${container_user}:${container_user} /home/${container_user}
 
 # select container user for all tasks


### PR DESCRIPTION
Issue:
libssl.so.3: cannot open shared object file: No such file or directory/usr/local/lib/softhsm/libpkcs11-proxy.so

As the master copy is updated with java 21 client.zip, change is to use java 11 compatible client.zip