### PR TITLE
[ES-2888] added proxy pass for par and dpop

### DIFF
--- a/docker-compose/nginx.conf
+++ b/docker-compose/nginx.conf
@@ -28,7 +28,24 @@ http {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
     }
-
+    location /mock-relying-party-service/requestUri {
+      proxy_pass         http://mock-relying-party-service:8888/requestUri;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Host $server_name;
+      proxy_http_version 1.1;
+    }
+    location /mock-relying-party-service/dpopJKT {
+      proxy_pass         http://mock-relying-party-service:8888/dpopJKT ;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Host $server_name;
+      proxy_http_version 1.1;
+    }
 
     location / {
       # alias /usr/share/nginx/html;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nginx proxy configuration with routing for two new mock service endpoints, enabling additional request handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->