### PR TITLE
[MOSIP-44489] set active_profile_env to "default" in deployment

### DIFF
--- a/mock-identity-system/configure_start.sh
+++ b/mock-identity-system/configure_start.sh
@@ -38,6 +38,12 @@ else
   echo "*** HSM Client installation is ignored in local profile ***"
 fi
 
+## set active profile if not set
+if [[ -z "$active_profile_env" ]]; then
+  echo "Alert: active_profile_env is not set. setting to default"
+  active_profile_env="default"
+  export active_profile_env
+fi
 
 cd $work_dir
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved startup script to set default environment configuration and enable direct command execution when arguments are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->