### PR TITLE
[mosip/mosip-infra#1890] Added domainConfig support in helm charts

### DIFF
--- a/helm/mock-identity-system/templates/deployment.yaml
+++ b/helm/mock-identity-system/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             {{- range .Values.extraEnvVarsCM }}

--- a/helm/mock-identity-system/values.yaml
+++ b/helm/mock-identity-system/values.yaml
@@ -504,3 +504,5 @@ istio:
   prefix: /v1/mock-identity-system/
 
 enable_insecure: false
+
+domainConfig: {}

--- a/helm/mock-identity-system/values.yaml
+++ b/helm/mock-identity-system/values.yaml
@@ -505,4 +505,5 @@ istio:
 
 enable_insecure: false
 
+# domainConfig entries are injected as container env vars; values must be scalar/string (maps/lists will not render correctly)
 domainConfig: {}

--- a/helm/mock-relying-party-service/templates/deployment.yaml
+++ b/helm/mock-relying-party-service/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := .Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
           envFrom:
             {{- if .Values.envVarsCM }}
               {{- range .Values.envVarsCM }}

--- a/helm/mock-relying-party-service/values.yaml
+++ b/helm/mock-relying-party-service/values.yaml
@@ -460,3 +460,5 @@ istio:
   reWritemock_relying_party_servicePrefix: ""
 
 enable_insecure: false
+
+domainConfig: {}

--- a/helm/mock-relying-party-service/values.yaml
+++ b/helm/mock-relying-party-service/values.yaml
@@ -461,4 +461,5 @@ istio:
 
 enable_insecure: false
 
+# domainConfig entries are injected as container env vars; values must be scalar/string (maps/lists will not render correctly)
 domainConfig: {}


### PR DESCRIPTION
## Summary
Cherry-pick of #589 from `develop` onto `release-0.13.x`: adds `domainConfig` support in the mock-identity-system and mock-relying-party-service helm charts (deployment.yaml and values.yaml), replacing `esignet-global` with a generic domainConfig values mechanism.

Original commit: mosip/esignet-mock-services@4cb75db46f693568578dcc46592d0bf8bfe9716d

## Test plan
- [ ] Verify helm template renders domainConfig env vars correctly for both charts
- [ ] Verify no regression for deployments without domainConfig set