### PR TITLE
[issue:597] Add PKCS12 keystore support to mock-identity-system as an alternative to SoftHSM

### DIFF
--- a/deploy/mock-identity-system/install.sh
+++ b/deploy/mock-identity-system/install.sh
@@ -59,14 +59,88 @@ function installing_mock-identity-system() {
     ENABLE_INSECURE='--set enable_insecure=true';
   fi
 
-  ../copy_cm_func.sh secret softhsm-mock-identity-system softhsm $NS
-  ../copy_cm_func.sh configmap softhsm-mock-identity-system-share softhsm $NS
+      while true; do
+    read -p "For PKCS12 mounted keys, opt 'y' to enable volume (y/n) [ default: n ]: " enable_volume
+    enable_volume=${enable_volume:-n}
+
+    if [[ "$enable_volume" == "y" || "$enable_volume" == "Y" ]]; then
+      enable_volume=true
+      break
+    elif [[ "$enable_volume" == "n" || "$enable_volume" == "N" ]]; then
+      enable_volume=false
+      break
+    else
+      echo "Invalid input. Please enter 'y' or 'n'."
+    fi
+  done
+
+  HSM_HELM_ARGS=''
+  if [[ $enable_volume == 'true' ]]; then
+    default_volume_size=100M
+    read -p "Provide the size for volume [ default : 100M ]" volume_size
+    volume_size=${volume_size:-$default_volume_size}
+
+    default_volume_mount_path='/home/mosip/config/'
+    read -p "Provide the mount path for volume [ default : '/home/mosip/config/' ] : " volume_mount_path
+    volume_mount_path=${volume_mount_path:-$default_volume_mount_path}
+
+    default_keystore_pass='1234'
+    read -p "Provide the PKCS12 keystore password [ default : 1234 ] : " keystore_pass
+    keystore_pass=${keystore_pass:-$default_keystore_pass}
+
+    kubectl -n $NS create secret generic mockid-pkcs12-secret \
+      --from-literal=keystore-pass="$keystore_pass" \
+      --dry-run=client -o yaml | kubectl apply -f -
+
+    pkcs12_env_file=$(mktemp)
+    cat <<EOF > "$pkcs12_env_file"
+extraEnvVarsAdditional:
+  - name: MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_TYPE
+    value: "PKCS12"
+  - name: MOSIP_KERNEL_KEYMANAGER_HSM_CONFIG_PATH
+    value: "${volume_mount_path}keystore.p12"
+  - name: MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mockid-pkcs12-secret
+        key: keystore-pass
+EOF
+
+    PVC_CLAIM_NAME='mockid-pkcs12'
+    HSM_HELM_ARGS="--set persistence.enabled=true  \
+                       --set volumePermissions.enabled=true \
+                       --set persistence.size=$volume_size \
+                       --set persistence.mountDir=\"$volume_mount_path\" \
+                       --set persistence.pvc_claim_name=\"$PVC_CLAIM_NAME\"  \
+                       -f $pkcs12_env_file \
+                      "
+  else
+    ../copy_cm_func.sh secret softhsm-mock-identity-system softhsm $NS
+    ../copy_cm_func.sh configmap softhsm-mock-identity-system-share softhsm $NS
+
+    softhsm_env_file=$(mktemp)
+    cat <<EOF > "$softhsm_env_file"
+extraEnvVarsAdditional:
+  - name: SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: softhsm-mock-identity-system
+        key: security-pin
+  - name: hsm_local_dir_name
+    value: hsm-client
+extraEnvVarsCM:
+  - softhsm-mock-identity-system-share
+EOF
+
+    HSM_HELM_ARGS="-f $softhsm_env_file"
+  fi
+
   ../copy_cm_func.sh configmap esignet-global esignet $NS
   ../copy_cm_func.sh configmap redis-config redis $NS
   ../copy_cm_func.sh secret redis redis $NS
 
   echo Installing mock-identity-system
-  helm -n $NS install mock-identity-system mosip/mock-identity-system --set metrics.serviceMonitor.enabled=$servicemonitorflag --version $CHART_VERSION $ENABLE_INSECURE -f values.yaml --wait
+  helm -n $NS install mock-identity-system mosip/mock-identity-system --set metrics.serviceMonitor.enabled=$servicemonitorflag --version $CHART_VERSION $ENABLE_INSECURE $HSM_HELM_ARGS -f values.yaml --wait
 
   kubectl -n $NS get deploy mock-identity-system -o name |  xargs -n1 -t  kubectl -n $NS rollout status
 

--- a/helm/mock-identity-system/templates/deployment.yaml
+++ b/helm/mock-identity-system/templates/deployment.yaml
@@ -60,15 +60,17 @@ spec:
           image: {{ include "mock-identity-system.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
-            - %%commands%%
+            - /bin/bash
+            - -c
+            - chown -R 1001:1001 {{ .Values.persistence.mountDir }}
           securityContext:
             runAsUser: 0
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: foo
-              mountPath: bar
+            - name: {{ .Values.persistence.volume_name }}
+              mountPath: {{ .Values.persistence.mountDir }}
         {{- end }}
         {{- if .Values.enable_insecure }}
           {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
@@ -96,6 +98,9 @@ spec:
               value: {{ .Values.additionalResources.javaOpts }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsAdditional }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsAdditional "context" $) | nindent 12 }}
             {{- end }}
             {{- range $key, $val := .Values.domainConfig }}
             - name: {{ $key }}
@@ -143,6 +148,10 @@ spec:
             name: cacerts
             subPath: cacerts
           {{- end }}
+          {{- if .Values.persistence.enabled }}
+          - name: {{ .Values.persistence.volume_name }}
+            mountPath: {{ .Values.persistence.mountDir }}
+          {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -150,4 +159,9 @@ spec:
       {{- if .Values.enable_insecure }}
       - name: cacerts
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
+      - name: {{ .Values.persistence.volume_name }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default .Values.persistence.pvc_claim_name }}
       {{- end }}

--- a/helm/mock-identity-system/templates/pvc.yaml
+++ b/helm/mock-identity-system/templates/pvc.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.persistence.pvc_claim_name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+  {{- if not (empty .Values.persistence.accessModes) }}
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+    - {{ .Values.persistence.accessModes | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+  {{- if .Values.persistence.dataSource }}
+  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/mock-identity-system/values.yaml
+++ b/helm/mock-identity-system/values.yaml
@@ -266,13 +266,6 @@ extraEnvVars:
       secretKeyRef:
         name: db-common-secrets
         key: db-dbuser-password
-  - name: SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN
-    valueFrom:
-      secretKeyRef:
-        name: softhsm-mock-identity-system
-        key: security-pin
-  - name: hsm_local_dir_name
-    value: hsm-client
   - name: MOSIP_ESIGNET_MOCK_SUPPORTED_FIELDS
     value: individualId,password
   - name: MOSIP_ESIGNET_HOST
@@ -296,10 +289,18 @@ extraEnvVars:
         name: redis
         key: redis-password
 
+## Additional environment variables to append on top of extraEnvVars, without
+## having to restate the entries already declared there
+## Example:
+## extraEnvVarsAdditional:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVarsAdditional: []
+
 ## ConfigMap with extra environment variables that used
 ##
-extraEnvVarsCM:
-  - softhsm-mock-identity-system-share
+extraEnvVarsCM: []
 
 ## Secret with extra environment variables
 ##
@@ -389,6 +390,8 @@ persistence:
   existingClaim:
   # Dir where config and keys are written inside container
   mountDir:
+  volume_name: config
+  pvc_claim_name:
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.


### PR DESCRIPTION
## Summary
Closes #597

- `install.sh` now prompts to opt into a PKCS12 mounted-volume keystore instead of SoftHSM, creates the keystore password secret (default `1234`, overridable), and wires the corresponding persistence/env config into the helm install.
- SoftHSM provisioning (secret/configmap copy, env vars) now only runs when PKCS12 is *not* selected — previously applied unconditionally regardless of choice.
- Helm chart (`helm/mock-identity-system`):
  - Added a `PersistentVolumeClaim` template (didn't exist before — `persistence.enabled` had no backing PVC resource).
  - Fixed the volume-permissions init container, which had a literal unfilled `%%commands%%` placeholder and stub `foo`/`bar` volume mount names — this caused a YAML parse error (`found character that cannot start any token`) the first time `persistence.enabled` + `volumePermissions.enabled` were actually exercised together.
  - Wired the persistence volume into the main container's `volumeMounts` and the pod's `volumes` (previously absent).
  - Added `extraEnvVarsAdditional` support (additive on top of `extraEnvVars`, doesn't require restating the whole list), matching the existing pattern in the `esignet` chart.

## Test plan
- [x] Verified chart renders cleanly via `helm template` for both the PKCS12 branch (PVC + persistence volume + PKCS12 env vars, zero SoftHSM references) and the SoftHSM branch (unchanged env vars/configmap, no PVC).
- [x] Ran `install.sh` end-to-end against a live cluster with PKCS12 opted in: PVC created and bound, keystore secret created, deployment came up with correct volume mounts and env vars.
- [ ] Run `install.sh` end-to-end with the default SoftHSM path (`n`) to confirm no regression, once the chart changes here are published (script currently references the chart by published version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistent storage for PKCS12 keystores during mock identity installation.
  * Added interactive configuration for storage size, mount path, and keystore password.
  * Added support for existing or newly created persistent volume claims.
  * Added configurable environment variables for eSignet mock services and Redis connections.

* **Bug Fixes**
  * Corrected persistence volume mounting and permission handling during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->