### PR TITLE
#2256 Fixed Default Prompt Value.

### DIFF
--- a/mock-relying-party-service/clientDetails.js
+++ b/mock-relying-party-service/clientDetails.js
@@ -26,7 +26,7 @@ const scopeRegistration = checkEmptyNullValue(
   "openid profile",
 );
 const display = checkEmptyNullValue(process.env.DISPLAY, "page");
-const prompt = checkEmptyNullValue(process.env.PROMPT, "consent");
+const prompt = process.env.PROMPT || null;
 const grantType = checkEmptyNullValue(
     process.env.GRANT_TYPE,
     "authorization_code",

--- a/mock-relying-party-service/esignetService.js
+++ b/mock-relying-party-service/esignetService.js
@@ -110,7 +110,9 @@ const post_GetRequestUri = async (clientId, uiLocales, state, dpop_jkt, code_cha
   params.append("claims", clientDetails.userProfileClaims);
   params.append("claims_locales", clientDetails.claimsLocales);
   params.append("display", clientDetails.display);
-  params.append("prompt", clientDetails.prompt);
+  if (clientDetails.prompt) {
+    params.append("prompt", clientDetails.prompt);
+  }
   params.append("ui_locales", uiLocales || process.env.DEFAULT_UI_LOCALES);
   params.append("client_assertion_type", CLIENT_ASSERTION_TYPE);
   params.append("client_assertion", clientAssertion);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when no prompt configuration is provided.
  * Prevented empty or undefined prompt values from being included in request URLs.
  * Requests now omit the prompt parameter unless it has been explicitly configured.

**Related Issue:** [#2256](https://github.com/mosip/esignet/issues/2256)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->