### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,183 @@
+# AGENTS.md
+
+## Repository Overview
+
+`esignet-mock-services` provides **mock, non-production implementations** that stand in for
+real MOSIP eSignet dependencies during development, demos, and testing:
+
+- A mock identity system that mimics the MOSIP IDA (Identity Authentication) system.
+- A mock relying-party backend and two mock relying-party UIs that demonstrate OIDC login
+  against eSignet.
+- A partner-onboarder job that registers the mock relying party as an OIDC client with MOSIP.
+
+**This is dev/test-only tooling.** None of the services in this repository perform real
+identity verification or issue real credentials — they return canned/synthetic identity data
+and use test keys. They must never be pointed at, or treated as, a production identity or
+credential-issuing system.
+
+This repo is a small tree of independently-buildable modules rather than one monolithic
+service. Each module has its own build tool, run instructions, and README. Use this root file
+to find your way to the module that matters for your change; use the module guide for the
+actual commands.
+
+| Module | What it is | Guide |
+|---|---|---|
+| `mock-identity-system` | Java/Spring Boot mock of the MOSIP IDA system (Maven module, built by the root `pom.xml`) | [mock-identity-system/AGENTS.md](mock-identity-system/AGENTS.md) |
+| `mock-relying-party-service` | Node.js/Express backend for the mock relying-party portal (OIDC/OAuth client, DPoP, PAR) | [mock-relying-party-service/AGENTS.md](mock-relying-party-service/AGENTS.md) |
+| `mock-relying-party-ui` | React UI for the generic mock relying-party portal | [mock-relying-party-ui/AGENTS.md](mock-relying-party-ui/AGENTS.md) |
+| `mock-relying-party-ui-esim` | React UI for the eSIM-branded mock relying-party portal | [mock-relying-party-ui-esim/AGENTS.md](mock-relying-party-ui-esim/AGENTS.md) |
+| `partner-onboarder` | Shell/Helm job that onboards the mock relying party as an OIDC partner | [partner-onboarder/AGENTS.md](partner-onboarder/AGENTS.md) |
+
+Non-module directories:
+
+- `db_scripts/` — PostgreSQL DDL/DML for `mosip_mockidentitysystem`. See `db_scripts/README.md`.
+  Deploy locally with `db_scripts/mosip_mockidentitysystem/deploy.sh`.
+- `db_upgrade_script/` — versioned DB upgrade scripts.
+- `docker-compose/` — Compose files to run the mock stack locally (see `docker-compose/README.md`).
+- `deploy/` and `helm/` — Kubernetes/Helm install scripts and charts for cluster deployment.
+- `docs/` — supporting images.
+
+## Technology Stack
+
+- **mock-identity-system**: Java 21, Spring Boot 3.4.11 (Spring Web, Spring Data JPA, Spring
+  Data Redis, Spring Cloud Config), Maven, PostgreSQL, springdoc-openapi, Lombok, JSON Schema
+  validation (`com.networknt:json-schema-validator`).
+- **mock-relying-party-service**: Node.js, Express, `jose` (JWT/JWK), `axios`, `joi`,
+  `node-cache`, `express-rate-limit`.
+- **mock-relying-party-ui** / **mock-relying-party-ui-esim**: React 18 (Create React App),
+  `react-router-dom`, `i18next`, Tailwind CSS.
+- **partner-onboarder**: shell scripts + Helm, driven by `values.yaml`.
+- **CI**: GitHub Actions, using shared reusable workflows from `mosip/kattu`
+  (`.github/workflows/push-trigger.yml`, `db-test.yml`, `chart-lint-publish.yml`,
+  `codeql.yml`, `release-changes.yml`, `tag.yml`).
+
+## Build & Test Commands
+
+Root Maven build (builds `mock-identity-system`, the only module declared in the root
+`pom.xml`):
+
+```shell
+mvn clean install -Dgpg.skip=true -DskipTests=true
+```
+
+Run the full test suite for `mock-identity-system` (includes JaCoCo coverage, configured in
+the parent `pom.xml`):
+
+```shell
+mvn -pl mock-identity-system test
+```
+
+Node-based modules (`mock-relying-party-service`, `mock-relying-party-ui`,
+`mock-relying-party-ui-esim`) each build independently with `npm install` / `npm start` /
+`npm run build` from inside their own directory. See the per-module guides for exact commands
+and required environment variables — commands differ per module and none of them share a
+single root build script.
+
+Each service/UI also has a `Dockerfile`; CI (`push-trigger.yml`) builds and pushes images for
+`mock-identity-system`, `mock-relying-party-service`, `mock-relying-party-ui`, and
+`mock-relying-party-ui-esim` via the shared `mosip/kattu` docker-build workflow.
+
+## Configuration
+
+- `mock-identity-system` configuration lives in
+  `mock-identity-system/src/main/resources/application-default.properties` and
+  `application-local.properties`, plus `bootstrap.properties` for Spring Cloud Config. The
+  local profile ships a non-secret local Postgres password (`postgres`) and a local HSM
+  keystore password (`localtest`) intended only for a throwaway local Postgres/HSM instance —
+  do not reuse these values, or any value copied from this repo, for a real deployment.
+- `mock-relying-party-service` is configured entirely through environment variables (no
+  committed secrets file) — see `mock-relying-party-service/README.md` for the full list,
+  including `CLIENT_PRIVATE_KEY` and `JWE_USERINFO_PRIVATE_KEY`, which must be supplied by
+  whoever runs the service and never committed.
+- `mock-relying-party-ui` and `mock-relying-party-ui-esim` are configured via `.env`,
+  `.env.development`, and (at container runtime) `public/env-config.js`. The tracked `.env`
+  files only set non-sensitive UI defaults (e.g. `REACT_APP_TOAST_TIMEOUT_IN_SEC`); real
+  per-environment values (client IDs, redirect URIs, service URLs) are supplied via
+  `env-config.js` or Docker `-e` flags at deploy time, not committed to the repo.
+- `partner-onboarder` is configured through `partner-onboarder/values.yaml` for Helm-based
+  runs.
+
+## Project Structure Notes
+
+- The root `pom.xml` is a Maven **parent/aggregator** POM but currently declares only one
+  `<module>`, `mock-identity-system`. The Node/React modules are siblings on disk but are not
+  part of the Maven reactor — they are built and deployed independently (own `Dockerfile`, own
+  CI matrix entry).
+- `mock-relying-party-ui` and `mock-relying-party-ui-esim` are two separate, independently
+  versioned React apps with overlapping purpose (generic vs. eSIM-branded relying-party demo
+  UI) — check which one a change actually targets before editing, since their `package.json`
+  and dependency sets differ.
+- CI workflow triggers are scoped by path where relevant: `db-test.yml` only runs on changes
+  under `db_scripts/**`; `chart-lint-publish.yml` only runs on changes under `helm/**`.
+  `push-trigger.yml` (the Maven/Docker build) runs on pushes/PRs regardless of path.
+  `codeql.yml` runs on pushes/PRs to `develop` and a weekly schedule.
+
+## Development Workflow
+
+1. Fork and clone the repository; add `upstream` pointing at `mosip/esignet-mock-services`.
+2. Branch from `upstream/develop` — `develop` is the integration branch this repo builds and
+   opens PRs against.
+3. Make changes inside the relevant module directory only; each module builds and runs
+   independently (see the module guide for exact local run steps).
+4. To exercise the mock identity system and relying-party portal together locally, use the
+   Compose files in `docker-compose/` as described in `docker-compose/README.md`.
+5. Run the relevant module's tests/build before opening a PR (`mvn -pl mock-identity-system
+   test` for the Java module; `npm test` / `npm run build` for the Node/React modules).
+
+## Pull Request Guidelines
+
+- Target the `develop` branch.
+- Keep changes scoped to the module(s) actually touched; avoid unrelated changes across
+  modules in the same PR.
+- CI (`push-trigger.yml`) builds the Maven module and all four Docker images
+  (`mock-identity-system`, `mock-relying-party-service`, `mock-relying-party-ui`,
+  `mock-relying-party-ui-esim`) on every PR — make sure each touched module still builds.
+- If you touch `db_scripts/**`, the `db-test.yml` workflow will run against PostgreSQL —
+  verify DDL/DML changes locally with `db_scripts/mosip_mockidentitysystem/deploy.sh` first.
+- If you touch `helm/**`, the `chart-lint-publish.yml` workflow will lint the charts.
+
+## Repository-Specific Considerations
+
+- Everything here is **mock/test tooling only** — the README states this explicitly
+  ("Only for non-production use", "This is not for production use"). Do not add code paths,
+  defaults, or documentation that imply this repo could serve as a real identity provider,
+  credential issuer, or relying party in production.
+- The mock identity system supports OIDC Identity Assurance verified-claims metadata
+  (`trust_framework`, `assurance_level`, `verification_process`, `time`, `evidence`) — see
+  `mock-identity-system/README.md` for the semantics before changing identity-schema
+  validation logic (`mock-identity-schema.json`).
+- The relying-party service and UI implement FAPI 2.0-adjacent security features (DPoP per
+  RFC 9449, PAR per RFC 9126, PKCE). Keep the service and UI README env-variable tables in
+  sync with actual code if you add/rename an environment variable.
+- When deploying multiple eSignet plugins into the same Kubernetes cluster, several Helm
+  install scripts require manual per-namespace overrides (service names, namespace) — see the
+  root `README.md` section "When deploying multiple esignet plugins in the same cluster."
+
+## Agent rules
+
+### Do
+
+1. Verify which module(s) a change actually touches (`mock-identity-system`,
+   `mock-relying-party-service`, `mock-relying-party-ui`, `mock-relying-party-ui-esim`,
+   `partner-onboarder`, or infra dirs) and read that module's own `README.md`/`AGENTS.md`
+   before editing.
+2. Build and test the specific module you changed before proposing a PR (Maven for
+   `mock-identity-system`, `npm` for the Node/React modules).
+3. Keep any new configuration documented as environment variables or properties files
+   consistent with the patterns already used in that module (no new secrets committed to the
+   repo).
+4. Preserve the "mock/non-production only" framing in any documentation you write or edit.
+
+### Do not
+
+1. Do not commit real credentials, private keys, or production URLs into `.env`,
+   `application-*.properties`, `values.yaml`, or any other config file — these services are
+   configured with secrets at deploy time (Docker `-e`, Helm values, environment variables),
+   not via committed files.
+2. Do not assume the root `pom.xml` builds the Node/React modules — it only builds
+   `mock-identity-system`. Do not add Maven-only build instructions and claim they cover the
+   whole repo.
+3. Do not treat `mock-relying-party-ui` and `mock-relying-party-ui-esim` as the same app —
+   verify which one you are changing.
+4. Do not describe this repository, in code or docs, as suitable for real identity
+   verification or credential issuance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,11 @@ Each service/UI also has a `Dockerfile`; CI (`push-trigger.yml`) builds and push
    independently (see the module guide for exact local run steps).
 4. To exercise the mock identity system and relying-party portal together locally, use the
    Compose files in `docker-compose/` as described in `docker-compose/README.md`.
-5. Run the relevant module's tests/build before opening a PR (`mvn -pl mock-identity-system
-   test` for the Java module; `npm test` / `npm run build` for the Node/React modules).
+5. Run the relevant module's documented test/build commands before opening a PR. For
+   `mock-identity-system`, run `mvn -pl mock-identity-system test`. For each Node/React
+   module, follow its own `AGENTS.md`/`README.md` — the available npm scripts differ
+   per module (e.g. `mock-relying-party-service` has no test script; `npm test` there
+   just exits with an error placeholder).
 
 ## Pull Request Guidelines
 

--- a/mock-identity-system/AGENTS.md
+++ b/mock-identity-system/AGENTS.md
@@ -31,7 +31,7 @@ production system at this module.
 Local setup (from the repo root, matching `docker-compose/README.md`):
 
 ```shell
-docker compose --file ../docker-compose/dependent-docker-compose.yml up
+docker compose --file docker-compose/dependent-docker-compose.yml up
 mvn clean install -Dgpg.skip=true -DskipTests=true
 ```
 

--- a/mock-identity-system/AGENTS.md
+++ b/mock-identity-system/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md — mock-identity-system
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+Mock implementation of the MOSIP IDA (Identity Authentication) system, used to demonstrate and
+test eSignet integration without a real identity backend. Supports `create-identity`,
+`get-identity`, `kyc-auth`, `kyc-exchange`, and adding OIDC Identity-Assurance verified-claims
+metadata for a user's claims. Supported authentication factors: PIN, OTP, BIO, PWD, WLA.
+
+This is a mock service — it stores and returns synthetic identity data only. Never point a
+production system at this module.
+
+## Layout
+
+- `src/main/java/io/mosip/esignet/mock/identitysystem/` — Spring Boot application code
+  (`controller/`, `service/`, `service/impl/`, `repository/`, `entity/`, `dto/`, `config/`,
+  `advice/`, `util/`, `exception/`).
+- `src/main/resources/` — `application-default.properties`, `application-local.properties`,
+  `bootstrap.properties`, `messages.properties`, and JSON schemas
+  (`mock-identity-schema.json`, `mock-identity-signup-schema.json`,
+  `mock-identity-ui-spec.json`, `mock-identity-signup-ui-spec.json`).
+- `src/test/java/...` — JUnit tests for controllers, services, and utilities.
+- `src/test/resources/` — `application-test.properties`, `bootstrap.properties`, `data.sql`,
+  `schema.sql` (H2 in-memory DB for tests), `mock-identity-test-schema.json`.
+- `Dockerfile`, `configure_start.sh`, `softhsm-application.conf` — container/runtime setup.
+
+## How to run
+
+Local setup (from the repo root, matching `docker-compose/README.md`):
+
+```shell
+docker compose --file ../docker-compose/dependent-docker-compose.yml up
+mvn clean install -Dgpg.skip=true -DskipTests=true
+```
+
+Then start `MockIdentitySystemApplication` from your IDE, or run the packaged jar. Swagger UI
+is served at:
+
+```text
+http://localhost:8082/v1/mock-identity-system/swagger-ui.html
+```
+
+Add a test identity:
+
+```shell
+curl -X 'POST' \
+  'http://localhost:8082/v1/mock-identity-system/identity' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{"requestTime": "2023-07-24T08:53:05.142Z", "request": {"individualId":"8267411571","pin":"111111"}}'
+```
+
+Run tests only (from repo root):
+
+```shell
+mvn -pl mock-identity-system test
+```
+
+## Configuration
+
+- `src/main/resources/application-local.properties` points at a local Postgres
+  (`localhost:5455`, db `mosip_mockidentitysystem`) and local Redis (`spring.cache.type=simple`
+  is explicitly a non-production cache mode). The Postgres password (`postgres`) and HSM
+  keystore password (`localtest`) in this file are throwaway values for a local dev database
+  only — never reuse them for a real deployment.
+- Schema validation is driven by `mosip.mock.ida.identity.schema.url` (defaults to
+  `classpath:/mock-identity-schema.json`). Create operations validate all fields against the
+  schema; update operations validate mandatory fields, and validate non-mandatory fields only
+  if present (see `mosip.mock.ida.update-identity.non-mandatory.fields`).
+- Database DDL/DML live outside this module, under `../db_scripts/mosip_mockidentitysystem/`.
+
+## Agent rules
+
+### Do
+
+1. Run `mvn -pl mock-identity-system test` after any change under `src/main/java` or
+   `src/main/resources`.
+2. Keep `mock-identity-schema.json` (and the corresponding test schema in
+   `src/test/resources/mock-identity-test-schema.json`) in sync when adding/removing identity
+   fields.
+3. Add new JUnit tests alongside existing ones under
+   `src/test/java/io/mosip/esignet/mock/identitysystem/...`, mirroring the package of the code
+   under test.
+
+### Do not
+
+1. Do not commit real Postgres/HSM/Redis credentials into `application-*.properties`.
+2. Do not add production-facing identity-verification logic here — this module exists purely
+   to mock IDA responses for eSignet integration testing.

--- a/mock-relying-party-service/AGENTS.md
+++ b/mock-relying-party-service/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md — mock-relying-party-service
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+Node.js/Express backend for the Mock Relying Party portal. Provides OAuth 2.0/OIDC integration
+with eSignet, including DPoP (RFC 9449) and PAR (RFC 9126) support. This is a reference/demo
+relying-party backend, not a production OIDC client implementation.
+
+## Layout
+
+- `app.js` — Express app entry point and route wiring.
+- `esignetService.js` — calls out to the eSignet OIDC endpoints (token, PAR, userinfo).
+- `cacheClient.js` — in-memory cache (`node-cache`) for DPoP key pairs, keyed by `clientId` +
+  `state`, TTL 10 minutes (not configurable).
+- `clientDetails.js`, `config.js`, `utils.js` — client/config helpers.
+- `package.json` — declares `start` (`node app.js`) and `devstart` (`node app.js && nodemon .`)
+  scripts. There is no test script (`npm test` currently just exits with an error placeholder).
+
+## Endpoints
+
+- `GET /dpopJKT?clientId=&state=` — generates a DPoP key pair, returns the JWK thumbprint.
+- `GET /requestUri/:clientId` — retrieves the PAR request URI.
+- `POST /fetchUserInfo` — exchanges an authorization code for a token and user info.
+
+See `README.md` in this directory for full request/response shapes and error codes.
+
+## How to run
+
+```shell
+npm install
+export PORT=8888
+export ESIGNET_SERVICE_URL='https://esignet.example-domain.test/v1/esignet'
+export ESIGNET_AUD_URL='https://esignet.example-domain.test/v1/esignet/oauth/v2/token'
+export CLIENT_PRIVATE_KEY='base64-encoded-private-key-jwk'
+export REDIRECT_URI='https://your-domain.example.test/userprofile'
+export SCOPE_USER_PROFILE='openid profile'
+export ACRS='mosip:idp:acr:linked-wallet mosip:idp:acr:knowledge mosip:idp:acr:generated-code mosip:idp:acr:password'
+npm start
+```
+
+For PAR-enabled setups, also set `ESIGNET_PAR_ENDPOINT` and `ESIGNET_PAR_AUD_URL`. The full
+environment-variable list (including the optional FAPI 2.0 / PAR / DPoP variables) is
+documented in this directory's `README.md`.
+
+Docker:
+
+```shell
+docker build -t mock-relying-party-service:local .
+docker run -it -d -p 8888:8888 \
+  --env ESIGNET_SERVICE_URL='https://esignet.example-domain.test/v1/esignet' \
+  --env ESIGNET_AUD_URL='https://esignet.example-domain.test/v1/esignet/oauth/v2/token' \
+  --env CLIENT_PRIVATE_KEY='base64-encoded-private-key-jwk' \
+  --env REDIRECT_URI='https://your-domain.example.test/userprofile' \
+  --env SCOPE_USER_PROFILE='openid profile' \
+  --env ACRS='mosip:idp:acr:linked-wallet mosip:idp:acr:knowledge mosip:idp:acr:generated-code mosip:idp:acr:password' \
+  mock-relying-party-service:local
+```
+
+## Configuration
+
+All configuration is via environment variables — there is no committed secrets file.
+`CLIENT_PRIVATE_KEY` is required; `JWE_USERINFO_PRIVATE_KEY` is required only when
+`USERINFO_RESPONSE_TYPE=jwe`. Never commit real values for these into the repo, `Dockerfile`,
+or any compose file.
+
+## Agent rules
+
+### Do
+
+1. Keep the environment-variable table in `README.md` in sync with any new/renamed variable
+   read from `process.env` in `app.js`/`config.js`.
+2. Preserve the 10-minute, non-configurable TTL behavior of the DPoP cache in `cacheClient.js`
+   unless the change explicitly intends to make it configurable — and if so, update the
+   `README.md` accordingly.
+
+### Do not
+
+1. Do not commit `CLIENT_PRIVATE_KEY`, `JWE_USERINFO_PRIVATE_KEY`, or any other secret value
+   into source, `Dockerfile`, or example compose files.
+2. Do not add a real test script without checking whether `package.json`'s current placeholder
+   `test` script is intentionally deferred — coordinate the change with the module README.

--- a/mock-relying-party-ui-esim/AGENTS.md
+++ b/mock-relying-party-ui-esim/AGENTS.md
@@ -39,7 +39,7 @@ Docker:
 docker build -t mock-relying-party-ui-esim:local .
 docker run -it -d -p 5000:5000 \
   -e ESIGNET_UI_BASE_URL='http://localhost:3000' \
-  -e MOCK_RELYING_PARTY_BASE_URL=http://localhost:8888 \
+  -e MOCK_RELYING_PARTY_SERVER_URL=http://localhost:8888 \
   -e REDIRECT_URI=http://localhost:5000/userprofile \
   -e CLIENT_ID=esim \
   -e ACRS="mosip:esignet:acr:static-code" \

--- a/mock-relying-party-ui-esim/AGENTS.md
+++ b/mock-relying-party-ui-esim/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md — mock-relying-party-ui-esim
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+React (Create React App) UI for the eSIM-branded mock relying-party portal, showcasing OIDC
+protocol integration with eSignet. Same two-page flow as `mock-relying-party-ui` (Home page
+with "Sign in with MOSIP", User Profile page after authentication), packaged as a distinct app
+(`package.json` name: `fyntel-app`).
+
+This is a demo/reference UI, not a production relying-party frontend.
+
+## Layout
+
+- `src/` — React application source.
+- `public/` — static assets, including `env-config.js` for runtime configuration.
+- `.env`, `.env.development` — build-time defaults.
+- `nginx/` — nginx config used by the `Dockerfile`.
+- `package.json` — CRA scripts: `start`, `build`, `test`, `eject`. Distinct dependency set
+  from `mock-relying-party-ui` (e.g. TypeScript, `workbox-webpack-plugin`, `ajv` devDependencies
+  present here but not in the sibling UI module).
+
+## How to run
+
+```shell
+npm install
+npm start
+```
+
+Runs on port 5000 by default. Update `public/env-config.js` per this directory's `README.md`
+before running: `ESIGNET_UI_BASE_URL`, `MOCK_RELYING_PARTY_SERVER_URL`, `REDIRECT_URI`,
+`CLIENT_ID`, `ACRS`, `SCOPE_USER_PROFILE`, and optional `MAX_AGE`, `DISPLAY`, `PROMPT`,
+`GRANT_TYPE`, `SIGN_IN_BUTTON_PLUGIN_URL`.
+
+Docker:
+
+```shell
+docker build -t mock-relying-party-ui-esim:local .
+docker run -it -d -p 5000:5000 \
+  -e ESIGNET_UI_BASE_URL='http://localhost:3000' \
+  -e MOCK_RELYING_PARTY_BASE_URL=http://localhost:8888 \
+  -e REDIRECT_URI=http://localhost:5000/userprofile \
+  -e CLIENT_ID=esim \
+  -e ACRS="mosip:esignet:acr:static-code" \
+  -e SCOPE_USER_PROFILE='openid%20profile%20resident-service' \
+  mock-relying-party-ui-esim:local
+```
+
+To host on a context path, edit the nginx `location /` block and pass `MOCK_RP_UI_PUBLIC_URL`
+at `docker run` time — see this directory's `README.md`.
+
+Run tests:
+
+```shell
+npm test
+```
+
+## Configuration
+
+Runtime configuration is read from `public/env-config.js`, populated at container start. See
+this directory's `README.md` for the full variable list.
+
+## Agent rules
+
+### Do
+
+1. Update this directory's `README.md` environment-variable list whenever you add, rename, or
+   remove a variable read from `env-config.js`.
+2. Treat this module as independent from `mock-relying-party-ui` — do not assume a fix here
+   also applies there, or vice versa.
+
+### Do not
+
+1. Do not hardcode real client IDs, redirect URIs, or private keys into source or committed
+   `.env`/`env-config.js`.
+2. Do not assume this module's `package.json` matches `mock-relying-party-ui`'s — verify
+   before copying dependency or script changes across.

--- a/mock-relying-party-ui/AGENTS.md
+++ b/mock-relying-party-ui/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — mock-relying-party-ui
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+React (Create React App) reference implementation of a relying party's portal, demonstrating
+OIDC-based login against MOSIP eSignet. Two pages: a Home page with "Sign in with MOSIP", and
+a User Profile page shown after successful authentication.
+
+This is a demo/reference UI, not a production relying-party frontend — do not present it as
+one.
+
+## Layout
+
+- `src/` — React application source.
+- `public/` — static assets, including `env-config.js`, which holds runtime-configurable
+  values consumed at container start (as opposed to build-time `.env` values).
+- `.env`, `.env.development` — build-time defaults (only non-sensitive values are tracked,
+  e.g. `REACT_APP_TOAST_TIMEOUT_IN_SEC`).
+- `nginx/` — nginx config used by the `Dockerfile` to serve the built app and proxy to the
+  mock relying-party backend.
+- `package.json` — CRA scripts: `start`, `build`, `test`, `eject`.
+
+## How to run
+
+```shell
+npm install
+npm start
+```
+
+The app runs on port 5000 by default. Before running, update
+`mock-relying-party-ui/public/env-config.js` with the required values (see README table below
+for the full variable list): `ESIGNET_UI_BASE_URL`, `MOCK_RELYING_PARTY_SERVER_URL`,
+`AUTHORIZE_ENDPOINT`, `REDIRECT_URI`, `CLIENT_ID`, `ACRS`, `SCOPE_USER_PROFILE`, `GRANT_TYPE`,
+and the optional `MAX_AGE`, `DISPLAY`, `PROMPT`, `PAR_CALLBACK_NAME`, `PAR_CALLBACK_TIMEOUT`,
+`DPOP_CALLBACK_NAME`, `CODE_CHALLENGE`.
+
+Docker:
+
+```shell
+docker build -t mock-relying-party-ui:local .
+docker run -it -d -p 5000:5000 \
+  -e ESIGNET_UI_BASE_URL='http://localhost:3000' \
+  -e MOCK_RELYING_PARTY_SERVER_URL=http://localhost:8888 \
+  -e REDIRECT_URI=http://localhost:5000/userprofile \
+  -e CLIENT_ID=healthservices \
+  -e ACRS="mosip:esignet:acr:static-code" \
+  -e SCOPE_USER_PROFILE='openid%20profile%20resident-service' \
+  mock-relying-party-ui:local
+```
+
+To host on a context path, edit the nginx `location /` block in `nginx/` and pass
+`MOCK_RP_UI_PUBLIC_URL` at `docker run` time — see this directory's `README.md` for the exact
+nginx snippet.
+
+Run tests:
+
+```shell
+npm test
+```
+
+## Configuration
+
+Runtime configuration is read from `public/env-config.js` (populated at container start), not
+rebuilt into the JS bundle per environment. See the full variable table in this directory's
+`README.md`, including which flags are feature toggles with hardcoded callback names
+(`PAR_CALLBACK_NAME`, `DPOP_CALLBACK_NAME`, `CODE_CHALLENGE`).
+
+## Agent rules
+
+### Do
+
+1. Update `README.md`'s environment-variable table whenever you add, rename, or remove a
+   variable read from `env-config.js`.
+2. Keep this module's dependency set (`package.json`) independent from
+   `mock-relying-party-ui-esim` — they are separate apps with separate release cadences even
+   though the code is similar.
+
+### Do not
+
+1. Do not hardcode a real `ESIGNET_UI_BASE_URL`, `CLIENT_ID`, or private key value into source
+   or committed `.env`/`env-config.js` — these are supplied at deploy time.
+2. Do not merge changes intended for `mock-relying-party-ui-esim` into this module or vice
+   versa without checking both READMEs — they diverge in dependencies and branding.

--- a/partner-onboarder/AGENTS.md
+++ b/partner-onboarder/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — partner-onboarder
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+Onboards the mock relying party as an OIDC partner with MOSIP by exchanging certificates, so
+that the mock relying-party portal can be used against a real eSignet deployment (identity
+plugin). See the [mosip-onboarding repo](https://github.com/mosip/mosip-onboarding) for the
+underlying onboarding job this wraps. Only needed when the `mosip-identity` plugin is used
+(per the root `README.md`).
+
+## Layout
+
+- `install.sh` — runs the onboarding job.
+- `delete.sh` — removes the onboarding job/resources.
+- `values.yaml` — Helm values controlling which modules the onboarder runs for.
+
+## How to run
+
+```shell
+# edit values.yaml to select the modules to onboard, then:
+./install.sh
+```
+
+Onboarding produces an HTML report, stored at the configured S3 bucket / NFS directory. Check
+this report to confirm onboarding succeeded before assuming the job passed.
+
+## Configuration
+
+All configuration is via `values.yaml` (Helm values) — set it before running `install.sh`.
+
+## Troubleshooting
+
+(From this directory's `README.md`.)
+
+- `KER-ATH-401: Authentication Failed` — provide the correct secret key for
+  `mosip-deployment-client`.
+- "Certificate dates are not valid" — check with the admin about adding a grace period in
+  configuration.
+- "Upload of certificate will not be allowed to update other domain certificate" — expected
+  when re-uploading an `ida-cred` certificate a second time; the onboarding job should only run
+  once, and this can be ignored if the cert is already present.
+
+## Agent rules
+
+### Do
+
+1. Confirm `values.yaml` targets the correct namespace and module list before running
+   `install.sh` against any shared cluster.
+2. Check the generated HTML onboarding report after every run to confirm success — a
+   completed job is not the same as a successful onboarding.
+
+### Do not
+
+1. Do not commit real `mosip-deployment-client` secret keys or certificates into `values.yaml`.
+2. Do not re-run onboarding for an already-onboarded `ida-cred` certificate expecting a clean
+   result — the "upload not allowed" error on a second run is expected, not a failure to fix.

--- a/partner-onboarder/AGENTS.md
+++ b/partner-onboarder/AGENTS.md
@@ -5,8 +5,10 @@ Parent guide: [../AGENTS.md](../AGENTS.md)
 ## Purpose
 
 Onboards the mock relying party as an OIDC partner with MOSIP by exchanging certificates, so
-that the mock relying-party portal can be used against a real eSignet deployment (identity
-plugin). See the [mosip-onboarding repo](https://github.com/mosip/mosip-onboarding) for the
+that the mock relying-party portal can be used against a non-production eSignet deployment
+(identity plugin) — this repo is only for non-production use (per the root `README.md`), even
+though `install.sh`/`values.yaml` accept inputs (public domains, certificates, S3/NFS config)
+that could target a production-style cluster. See the [mosip-onboarding repo](https://github.com/mosip/mosip-onboarding) for the
 underlying onboarding job this wraps. Only needed when the `mosip-identity` plugin is used
 (per the root `README.md`).
 


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md hub plus per-module AGENTS.md guides (mock-identity-system, mock-relying-party-service, mock-relying-party-ui, mock-relying-party-ui-esim, partner-onboarder) documenting purpose, layout, build/run/test commands, configuration, and agent do/do-not rules for AI coding assistants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development guides for the repository and its modules.
  * Documented setup, testing, configuration, project structure, workflows, and contribution guidelines.
  * Clarified service capabilities, endpoint usage, runtime configuration, Docker workflows, and troubleshooting steps.
  * Added guidance for onboarding workflows, report verification, and operational support.
  * Reinforced security practices, secret handling, mock-only usage, module isolation, and deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->