### PR TITLE
fix: 602 convert extraEnvVars/extraEnvVarsAdditional to maps

### DIFF
--- a/deploy/mock-identity-system/install.sh
+++ b/deploy/mock-identity-system/install.sh
@@ -95,11 +95,9 @@ function installing_mock-identity-system() {
     pkcs12_env_file=$(mktemp)
     cat <<EOF > "$pkcs12_env_file"
 extraEnvVarsAdditional:
-  - name: MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_TYPE
-    value: "PKCS12"
-  - name: MOSIP_KERNEL_KEYMANAGER_HSM_CONFIG_PATH
-    value: "${volume_mount_path}keystore.p12"
-  - name: MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_PASS
+  MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_TYPE: "PKCS12"
+  MOSIP_KERNEL_KEYMANAGER_HSM_CONFIG_PATH: "${volume_mount_path}keystore.p12"
+  MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_PASS:
     valueFrom:
       secretKeyRef:
         name: mockid-pkcs12-secret
@@ -121,13 +119,12 @@ EOF
     softhsm_env_file=$(mktemp)
     cat <<EOF > "$softhsm_env_file"
 extraEnvVarsAdditional:
-  - name: SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN
+  SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN:
     valueFrom:
       secretKeyRef:
         name: softhsm-mock-identity-system
         key: security-pin
-  - name: hsm_local_dir_name
-    value: hsm-client
+  hsm_local_dir_name: hsm-client
 extraEnvVarsCM:
   - softhsm-mock-identity-system-share
 EOF

--- a/helm/mock-identity-system/templates/deployment.yaml
+++ b/helm/mock-identity-system/templates/deployment.yaml
@@ -96,11 +96,21 @@ spec:
               value: {{ .Values.containerSecurityContext.runAsUser }}
             - name: JDK_JAVA_OPTIONS
               value: {{ .Values.additionalResources.javaOpts }}
-            {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVars }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
-            {{- if .Values.extraEnvVarsAdditional }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsAdditional "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVarsAdditional }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
             {{- range $key, $val := .Values.domainConfig }}
             - name: {{ $key }}

--- a/helm/mock-identity-system/values.yaml
+++ b/helm/mock-identity-system/values.yaml
@@ -234,69 +234,71 @@ customReadinessProbe: {}
 updateStrategy:
   type: RollingUpdate
 
-## Additional environment variables to set
+## Additional environment variables to set, keyed by env var name.
 ## Example:
 ## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
+##   FOO: "bar"
+##   BAZ:
+##     valueFrom:
+##       configMapKeyRef:
+##         name: some-configmap
+##         key: some-key
 ##
 extraEnvVars:
-  - name: DATABASE_HOST
+  DATABASE_HOST:
     valueFrom:
       configMapKeyRef:
         name: mockid-postgres-config
         key: database-host
-  - name: DATABASE_PORT
+  DATABASE_PORT:
     valueFrom:
       configMapKeyRef:
         name: mockid-postgres-config
         key: database-port
-  - name: DATABASE_NAME
+  DATABASE_NAME:
     valueFrom:
       configMapKeyRef:
         name: mockid-postgres-config
         key: database-name
-  - name: DATABASE_USERNAME
+  DATABASE_USERNAME:
     valueFrom:
       configMapKeyRef:
         name: mockid-postgres-config
         key: database-username
-  - name: DB_DBUSER_PASSWORD
+  DB_DBUSER_PASSWORD:
     valueFrom:
       secretKeyRef:
         name: db-common-secrets
         key: db-dbuser-password
-  - name: MOSIP_ESIGNET_MOCK_SUPPORTED_FIELDS
-    value: individualId,password
-  - name: MOSIP_ESIGNET_HOST
+  MOSIP_ESIGNET_MOCK_SUPPORTED_FIELDS: individualId,password
+  MOSIP_ESIGNET_HOST:
     valueFrom:
       configMapKeyRef:
         name: esignet-global
         key: mosip-esignet-host
-  - name: REDIS_HOST
+  REDIS_HOST:
     valueFrom:
       configMapKeyRef:
         name: redis-config
         key: redis-host
-  - name: REDIS_PORT
+  REDIS_PORT:
     valueFrom:
       configMapKeyRef:
         name: redis-config
         key: redis-port
-  - name: REDIS_PASSWORD
+  REDIS_PASSWORD:
     valueFrom:
       secretKeyRef:
         name: redis
         key: redis-password
 
 ## Additional environment variables to append on top of extraEnvVars, without
-## having to restate the entries already declared there
+## having to restate the entries already declared there. Keyed by env var name.
 ## Example:
 ## extraEnvVarsAdditional:
-##   - name: FOO
-##     value: "bar"
+##   FOO: "bar"
 ##
-extraEnvVarsAdditional: []
+extraEnvVarsAdditional: {}
 
 ## ConfigMap with extra environment variables that used
 ##

--- a/helm/mock-relying-party-service/templates/deployment.yaml
+++ b/helm/mock-relying-party-service/templates/deployment.yaml
@@ -104,8 +104,13 @@ spec:
                   name: jwe-userinfo-service-secrets
             - name: USERINFO_RESPONSE_TYPE
               value: {{ .Values.mock_relying_party_service.USERINFO_RESPONSE_TYPE }}
-            {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVars }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
             {{- range $key, $val := .Values.domainConfig }}
             - name: {{ $key }}

--- a/helm/mock-relying-party-service/values.yaml
+++ b/helm/mock-relying-party-service/values.yaml
@@ -241,14 +241,13 @@ customReadinessProbe: {}
 updateStrategy:
   type: RollingUpdate
 
-## Additional environment variables to set
+## Additional environment variables to set, keyed by env var name.
 ## Example:
 ## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
+##   FOO: "bar"
 ##
 ## TODO: the below env variable is not used, but required.  Remove it later
-extraEnvVars: []
+extraEnvVars: {}
 
 ## ConfigMap with extra environment variables
 ##

--- a/helm/mock-relying-party-ui/templates/deployment.yaml
+++ b/helm/mock-relying-party-ui/templates/deployment.yaml
@@ -127,8 +127,13 @@ spec:
             - name: FALLBACK_LANG
               value: {{ .Values.mock_relying_party_ui.FALLBACK_LANG | quote }}
 
-            {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- range $key, $val := .Values.extraEnvVars }}
+            - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- include "common.tplvalues.render" (dict "value" $val "context" $) | nindent 14 }}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end }}
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}

--- a/helm/mock-relying-party-ui/values.yaml
+++ b/helm/mock-relying-party-ui/values.yaml
@@ -234,13 +234,12 @@ customReadinessProbe: {}
 updateStrategy:
   type: RollingUpdate
 
-## Additional environment variables to set
+## Additional environment variables to set, keyed by env var name.
 ## Example:
 ## extraEnvVars:
-##   - name: FOO
-##     value: "bar"
+##   FOO: "bar"
 ##
-extraEnvVars: []
+extraEnvVars: {}
 
 ## ConfigMap with extra environment variables
 ##


### PR DESCRIPTION
## Summary
- Fixes #602
- Converts `extraEnvVars`/`extraEnvVarsAdditional` from YAML lists to native YAML maps
  (keyed by env var name) in `mock-identity-system`, `mock-relying-party-service`, and
  `mock-relying-party-ui`, and updates each chart's `templates/deployment.yaml` to render
  them with a `range $key, $val :=` loop that auto-detects a plain scalar (→ `value:`) vs. a
  `valueFrom` map (→ passed through `common.tplvalues.render`), matching the existing
  `domainConfig` map's rendering style already used in these charts.
- Root cause and fix pattern are identical to
  [mosip/esignet#2380](https://github.com/mosip/esignet/issues/2380) /
  [mosip/esignet#2381](https://github.com/mosip/esignet/pull/2381): Helm deep-merges map keys
  across values layers but replaces lists wholesale, so any downstream override had to
  restate the entire list just to change one entry.
- `mock-relying-party-service` and `mock-relying-party-ui` had empty `extraEnvVars: []`
  defaults (no real content to convert) — just changed to `{}` for consistency and to make
  future overrides map-shaped from the start.
- `mock-identity-system` is the only chart here with both `extraEnvVars` (10 real entries)
  and `extraEnvVarsAdditional`; the other two only use `extraEnvVars`.

## Test plan
- [x] `helm lint` passes for all three charts.
- [x] `helm template` rendered `env:` block for `mock-identity-system` (the chart with real
      content) compared before/after (list vs. map values.yaml) — every name/value/valueFrom
      matches exactly (only cosmetic diff: values now explicitly quoted).
- [x] `mock-relying-party-service`/`mock-relying-party-ui` render without error post-change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated Helm configuration for mock services to define additional environment variables using name-keyed maps.
  - Supports both direct scalar values and structured references to ConfigMaps or Secrets.
  - Improved environment-variable rendering across mock identity, relying-party service, and relying-party UI deployments.
  - Updated configuration examples and defaults to reflect the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->